### PR TITLE
fix: use apps/v1 deployment for operator

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -53,7 +53,7 @@ spec:
           name: randomsecret-operator
           namespace: randomsecret
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: randomsecret-operator


### PR DESCRIPTION
for support past k8s 1.16